### PR TITLE
Fix valid check

### DIFF
--- a/src/BitMask.php
+++ b/src/BitMask.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Cruxinator\BitMask;
 
 use BadMethodCallException;
-use UnexpectedValueException;
 use MyCLabs\Enum\Enum;
+use UnexpectedValueException;
 
 abstract class BitMask extends Enum
 {
@@ -63,7 +63,7 @@ abstract class BitMask extends Enum
     {
         if (!isset(static::$cache[static::class])) {
             $array = parent::toArray();
-            array_walk($array, function ($item) {
+            array_walk($array, function ($item): void {
                 if (!is_integer($item)) {
                     throw new UnexpectedValueException(sprintf('All defined Const on Enum %s should be integers', static::class));
                 }

--- a/src/BitMask.php
+++ b/src/BitMask.php
@@ -61,15 +61,15 @@ abstract class BitMask extends Enum
      */
     public static function toArray()
     {
-        if (!isset(static::$cache[static::class])) {
-            $array = parent::toArray();
-            array_walk($array, function ($item): void {
-                if (!is_integer($item)) {
-                    throw new UnexpectedValueException(sprintf('All defined Const on Enum %s should be integers', static::class));
-                }
-            });
-        }
+        $firstTime = !isset(static::$cache[static::class]);
         $array = parent::toArray();
+        $firstTime && array_walk($array, function ($item) {
+            if (!is_integer($item)) {
+                throw new UnexpectedValueException(
+                    sprintf('All defined Const on Enum %s should be integers', static::class)
+                );
+            }
+        });
         return $array;
     }
 

--- a/src/BitMask.php
+++ b/src/BitMask.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Cruxinator\BitMask;
 
 use BadMethodCallException;
+use UnexpectedValueException;
 use MyCLabs\Enum\Enum;
 
 abstract class BitMask extends Enum
@@ -60,13 +61,15 @@ abstract class BitMask extends Enum
      */
     public static function toArray()
     {
-        $array = parent::toArray();
-        //TODO: check that the array is defined correctly. basically check everything in the array is a int.
-        /*$array = array_filter($array, function ($temp) {
-            $raw = log($temp, 2);
-            return is_int($temp) && 0.01 > abs($raw - round($raw));
+        if (!isset(static::$cache[static::class])) {
+            $array = parent::toArray();
+            array_walk($array, function ($item) {
+                if (!is_integer($item)) {
+                    throw new UnexpectedValueException(sprintf('All defined Const on Enum %s should be integers', static::class));
+                }
+            });
         }
-        );*/
+        $array = parent::toArray();
         return $array;
     }
 

--- a/src/BitMask.php
+++ b/src/BitMask.php
@@ -62,8 +62,8 @@ abstract class BitMask extends Enum
     public static function toArray()
     {
         $firstTime = !isset(static::$cache[static::class]);
-        $array = parent::toArray();
-        $firstTime && array_walk($array, function ($item) {
+        $array     = parent::toArray();
+        $firstTime && array_walk($array, function ($item): void {
             if (!is_integer($item)) {
                 throw new UnexpectedValueException(
                     sprintf('All defined Const on Enum %s should be integers', static::class)

--- a/tests/BadBitMaskFixture.php
+++ b/tests/BadBitMaskFixture.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 
 namespace Cruxinator\BitMask\Tests;
-
 
 class BadBitMaskFixture extends BitMaskFixture
 {

--- a/tests/BadBitMaskFixture.php
+++ b/tests/BadBitMaskFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Cruxinator\BitMask\Tests;
+
+
+class BadBitMaskFixture extends BitMaskFixture
+{
+    const BadValue = 'no strings allowed';
+}

--- a/tests/BitmaskTest.php
+++ b/tests/BitmaskTest.php
@@ -86,4 +86,14 @@ class BitmaskTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($foo->isZERO());
         $this->assertFalse($foo->isTHIRTYTWO());
     }
+
+    public function testBadConst(): void
+    {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage(
+            'All defined Const on Enum Cruxinator\BitMask\Tests\BadBitMaskFixture should be integers'
+        );
+        $fixture = BadBitMaskFixture::BadValue();
+
+    }
 }

--- a/tests/BitmaskTest.php
+++ b/tests/BitmaskTest.php
@@ -94,6 +94,5 @@ class BitmaskTest extends \PHPUnit\Framework\TestCase
             'All defined Const on Enum Cruxinator\BitMask\Tests\BadBitMaskFixture should be integers'
         );
         $fixture = BadBitMaskFixture::BadValue();
-
     }
 }


### PR DESCRIPTION
So basically on fired request (before it has been cached by parent) we check that every entry in the array is a int.