### PR TITLE
Tweak constant filtering

### DIFF
--- a/src/BitMask.php
+++ b/src/BitMask.php
@@ -51,7 +51,7 @@ abstract class BitMask extends Enum
      * @throws \ReflectionException
      * @return bool
      */
-    public static function isValid($value)
+    public static function isValid($value): bool
     {
         $min = min(static::toArray());
         $max = max(static::toArray()) * 2 - 1;
@@ -62,7 +62,7 @@ abstract class BitMask extends Enum
      * @throws \ReflectionException
      * @return array
      */
-    public static function toArray()
+    public static function toArray(): array
     {
         $firstTime = !isset(static::$cache[static::class]);
         $array     = array_filter(parent::toArray(), function ($value): bool {
@@ -98,7 +98,7 @@ abstract class BitMask extends Enum
      * @throws \ReflectionException
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         $name  = $this->getName();
         $array = static::toArray();
@@ -111,7 +111,7 @@ abstract class BitMask extends Enum
             ']' . PHP_EOL;
     }
 
-    public function getName()
+    public function getName(): string
     {
         $path = explode('\\', __CLASS__);
         return array_pop($path);

--- a/src/BitMask.php
+++ b/src/BitMask.php
@@ -31,8 +31,8 @@ abstract class BitMask extends Enum
     /**
      * @param $name
      * @param $arguments
-     * @return bool|self
      * @throws \ReflectionException
+     * @return bool|self
      */
     public function __call($name, $arguments)
     {
@@ -48,8 +48,8 @@ abstract class BitMask extends Enum
 
     /**
      * @param $value
-     * @return bool
      * @throws \ReflectionException
+     * @return bool
      */
     public static function isValid($value)
     {
@@ -59,8 +59,8 @@ abstract class BitMask extends Enum
     }
 
     /**
-     * @return array
      * @throws \ReflectionException
+     * @return array
      */
     public static function toArray()
     {
@@ -79,6 +79,7 @@ abstract class BitMask extends Enum
     }
 
     /**
+     * @throws \ReflectionException
      * @return array|mixed
      */
     public function getKey()
@@ -94,6 +95,7 @@ abstract class BitMask extends Enum
     }
 
     /**
+     * @throws \ReflectionException
      * @return string
      */
     public function __toString()

--- a/src/BitMask.php
+++ b/src/BitMask.php
@@ -32,6 +32,7 @@ abstract class BitMask extends Enum
      * @param $name
      * @param $arguments
      * @return bool|self
+     * @throws \ReflectionException
      */
     public function __call($name, $arguments)
     {
@@ -48,6 +49,7 @@ abstract class BitMask extends Enum
     /**
      * @param $value
      * @return bool
+     * @throws \ReflectionException
      */
     public static function isValid($value)
     {
@@ -58,11 +60,14 @@ abstract class BitMask extends Enum
 
     /**
      * @return array
+     * @throws \ReflectionException
      */
     public static function toArray()
     {
         $firstTime = !isset(static::$cache[static::class]);
-        $array     = parent::toArray();
+        $array     = array_filter(parent::toArray(), function ($value): bool {
+            return is_scalar($value);
+        });
         $firstTime && array_walk($array, function ($item): void {
             if (!is_integer($item)) {
                 throw new UnexpectedValueException(

--- a/tests/BitMaskFixture.php
+++ b/tests/BitMaskFixture.php
@@ -29,6 +29,8 @@ use Cruxinator\BitMask\BitMask;
  */
 class BitMaskFixture extends BitMask
 {
+    protected const NON_FILTERABLE_VALUES = [2 => true, 4 => true];
+
     const ONE       = 1;
     const TWO       = 2;
     const FOUR      = 4;


### PR DESCRIPTION
Filter out non-scalar constants when casting the class as an array.  This should robustify bitmask usage against additional constants declared in the class.